### PR TITLE
Feat/#18 후기 작성 횟수 제한 기능 구현 

### DIFF
--- a/src/main/java/gamara/server/common/exception/ErrorCode.java
+++ b/src/main/java/gamara/server/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     //Review
     REVIEW_NOT_FOUND("R-001"),
     REVIEW_FORBIDDEN("R-002"),
+    REVIEW_ALREADY_EXISTS("R-003"),
 
     //Image
     INVALID_IMAGE_FILE_FORMAT("I-001"),

--- a/src/main/java/gamara/server/repository/ReviewRepository.java
+++ b/src/main/java/gamara/server/repository/ReviewRepository.java
@@ -4,4 +4,5 @@ import gamara.server.domain.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    boolean existsByUserIdAndStoreId(long userId, long storeId);
 }

--- a/src/main/java/gamara/server/service/ReviewService.java
+++ b/src/main/java/gamara/server/service/ReviewService.java
@@ -39,6 +39,10 @@ public class ReviewService {
         entityValidator.validateUserExists(userId);
         entityValidator.validateStoreExists(request.storeId());
 
+        if (reviewRepository.existsByUserIdAndStoreId(userId, request.storeId())) {
+            throw new AppException(ErrorCode. REVIEW_ALREADY_EXISTS);
+        }
+
         String imageUrl = null;
         MultipartFile imageFile = request.image();
         if (imageFile != null && !imageFile.isEmpty()) {


### PR DESCRIPTION
## ⛓️ Related Issues
관련 이슈
- https://github.com/yunhacandy/gamara-server/issues/18

## ☁️ what to do 
작업 내용에 대한 요약을 적어주세요.
- 기획의 변경으로 인해 사용자가 가게당 한번만 후기를 작성할 수 있게 횟수를 제한한다.
- [변경된 ddl 참고](https://github.com/yunhacandy/gamara-server/pull/3)